### PR TITLE
Comment out test that passes with static database of 300 todo entries

### DIFF
--- a/client/e2e/src/todo-list.e2e-spec.ts
+++ b/client/e2e/src/todo-list.e2e-spec.ts
@@ -39,6 +39,6 @@ describe('Todo list', () => {
       count++;
     });
     expect(count > 0);
-    expect(count === 300);
+    //expect(count === 300); - passes when using default "dev" database file w/300 todos. Otherwise, adding will break this test
   });
 });

--- a/client/src/app/todos/todo-list.component.spec.ts
+++ b/client/src/app/todos/todo-list.component.spec.ts
@@ -85,7 +85,7 @@ describe('Todo list', () => {
     expect(todoList.filteredTodos.filter((todo: Todo) => todo.category === 'swimming').length).toBe(0);
   });
 
-  // Break tests - sanity check (we expect these to fail) -> empty string for category actually does return no results
+  // Break tests - sanity check (we expect these to fail) -> empty string for category actually does return no results, so it passes
   // it('contains no todos with category "swimming', () => {
   //   expect(todoList.filteredTodos.filter((todo: Todo) => todo.category === 'swimming').length).toBe(5);
   // });


### PR DESCRIPTION
Fix false-negative test (will fail after new todos are added to the database).